### PR TITLE
Enable audio recording for all devices

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -5,6 +5,7 @@ on:
     branches: [ android-port, bitten-master ]
   pull_request:
     branches: [ android-port ]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ android-port, bitten-master ]
   pull_request:
-    branches: [ android ]
+    branches: [ android-port, bitten-master ]
 
 jobs:
   build:

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -8,7 +8,7 @@ else {
 }
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 29
     defaultConfig {
         if (buildAsApplication) {
             applicationId "org.stjr.srb2"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
 
     <!-- OpenGL ES 2.0 -->
     <uses-feature android:glEsVersion="0x00020000" />
+    <uses-feature android:allowAudioPlaybackCapture="true" />
 
     <!-- Touchscreen support -->
     <uses-feature
@@ -46,7 +47,6 @@
         android:isGame="true"
         android:allowBackup="true"
         android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
-        android:allowAudioPlaybackCapture="true"
         android:hardwareAccelerated="true" >
 
         <activity android:name="SRB2Game"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,6 @@
 
     <!-- OpenGL ES 2.0 -->
     <uses-feature android:glEsVersion="0x00020000" />
-    <uses-feature android:allowAudioPlaybackCapture="true" />
 
     <!-- Touchscreen support -->
     <uses-feature
@@ -52,6 +51,7 @@
         <activity android:name="SRB2Game"
             android:label="@string/app_name"
             android:alwaysRetainTaskState="true"
+            android:allowAudioPlaybackCapture="true"
             android:launchMode="singleInstance"
             android:hardwareAccelerated="true"
             android:configChanges="orientation|uiMode|screenLayout|screenSize|smallestScreenSize|keyboard|keyboardHidden|navigation"

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -46,6 +46,7 @@
         android:isGame="true"
         android:allowBackup="true"
         android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+        android:allowAudioPlaybackCapture="true"
         android:hardwareAccelerated="true" >
 
         <activity android:name="SRB2Game"


### PR DESCRIPTION
SRB2 would only allow for some devices to capture the audio while screen recording. This fixes it, and allows for all devices to record audio via a simple manifest change.